### PR TITLE
Defining browsers and Docker setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ and error with have an 'id' and 'message' parameter.
         }
     }
 
-2. Wait for notification to arrive
+1. Wait for notification to arrive
     Once your library has sent a message you can retrieve what details the
     browser received.
 
@@ -102,7 +102,7 @@ and error with have an 'id' and 'message' parameter.
         }
     }
 
-3. End the Test Suite
+1. End the Test Suite
     This will end and close any currently open tests.
 
     http://localhost:8090/api/end-test-suite/

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ and error with have an 'id' and 'message' parameter.
         }
     }
 
-1. Wait for notification to arrive
+2. Wait for notification to arrive
     Once your library has sent a message you can retrieve what details the
     browser received.
 
@@ -102,10 +102,18 @@ and error with have an 'id' and 'message' parameter.
         }
     }
 
-1. End the Test Suite
+3. End the Test Suite
     This will end and close any currently open tests.
 
     http://localhost:8090/api/end-test-suite/
 
     Input: {testSuiteId: <Your Test Suite ID>}
     Output: {data: {success: true}}
+
+### Specifying browsers
+
+Firefox and Chrome from three channels (`stable`, `beta`, `unstable`) are used by default. These values can be overridden by passing browsers and channels to the `start` call:
+
+```
+  web-push-testing-service start <Service Name> --browsers chrome,firefox --channels stable,beta
+```

--- a/src/cli/detached-service.js
+++ b/src/cli/detached-service.js
@@ -7,7 +7,8 @@ const WPTS = require('../index.js');
 // we want to be certain errors are surfaced
 try {
   const serviceValues = JSON.parse(process.argv[2]);
-  const webPushTestingService = new WPTS(serviceValues.port);
+  const webPushTestingService = new WPTS(serviceValues.port,
+    serviceValues.supportedBrowsers, serviceValues.supportedVersions);
   webPushTestingService.startService()
   .then(url => {
     const LINE = '---------------------------------' +

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -197,8 +197,8 @@ class WPTSCLI {
     console.log('    -h --help                     Show this screen.');
     console.log('    -p --port <Port Number>       Change port the service is run on.');
     console.log('       --log-file <Path>          Path and filename for logfile.');
-    console.log('       --browsers <B1,B2>         Override list of browsers to use.');
-    console.log('       --channels <C1,C2>         Override list of channels to use.');
+    console.log('       --browsers <Browser1, Browser2>         Override list of browsers to use.');
+    console.log('       --channels <ReleaseChannel1, ReleaseChannel2>         Override the browser versions tested on, can be "stable", "beta" and / or "unstable"');
     console.log('       --version                  Current version of CLI.');
     console.log('');
     /* eslint-enable line-length */

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -119,6 +119,16 @@ class WPTSCLI {
         options.logFile = flags['log-file'];
       }
 
+      if (flags.browsers) {
+        options.supportedBrowsers =
+          flags.browsers.split(',').map(i => i.trim());
+      }
+
+      if (flags.channels) {
+        options.supportedVersions =
+          flags.channels.split(',').map(i => i.trim());
+      }
+
       let stdioArgs = ['ipc', 'ignore', 'ignore'];
 
       // This is slightly hacky, but moves actual server to a bg process.
@@ -187,6 +197,8 @@ class WPTSCLI {
     console.log('    -h --help                     Show this screen.');
     console.log('    -p --port <Port Number>       Change port the service is run on.');
     console.log('       --log-file <Path>          Path and filename for logfile.');
+    console.log('       --browsers <B1,B2>         Override list of browsers to use.');
+    console.log('       --channels <C1,C2>         Override list of channels to use.');
     console.log('       --version                  Current version of CLI.');
     console.log('');
     /* eslint-enable line-length */

--- a/src/helper/browsers-helper.js
+++ b/src/helper/browsers-helper.js
@@ -13,7 +13,9 @@ Promise.all([
 ])
 .then(x => {
   console.log(`Downloaded browsers ${x}`);
+  process.exit(0);
 })
 .catch(e => {
   console.error(`Error occured while downloading browsers ${e}`);
+  process.exit(1);
 });

--- a/src/helper/browsers-helper.js
+++ b/src/helper/browsers-helper.js
@@ -4,7 +4,7 @@ require('chromedriver');
 const seleniumAssistant = require('selenium-assistant');
 
 Promise.all([
-  seleniumAssistant.downloadBrowser('firefox', 'stable', 48),
+  seleniumAssistant.downloadBrowser('firefox', 'stable', 50),
   seleniumAssistant.downloadBrowser('chrome', 'stable', 48)
 ])
 .then(x => {

--- a/src/helper/browsers-helper.js
+++ b/src/helper/browsers-helper.js
@@ -5,11 +5,7 @@ const seleniumAssistant = require('selenium-assistant');
 
 Promise.all([
   seleniumAssistant.downloadBrowser('firefox', 'stable', 48),
-  seleniumAssistant.downloadBrowser('firefox', 'beta', 48),
-  seleniumAssistant.downloadBrowser('firefox', 'unstable', 48),
-  seleniumAssistant.downloadBrowser('chrome', 'stable', 48),
-  seleniumAssistant.downloadBrowser('chrome', 'beta', 48),
-  seleniumAssistant.downloadBrowser('chrome', 'unstable', 48)
+  seleniumAssistant.downloadBrowser('chrome', 'stable', 48)
 ])
 .then(x => {
   console.log(`Downloaded browsers ${x}`);

--- a/src/helper/browsers-helper.js
+++ b/src/helper/browsers-helper.js
@@ -1,17 +1,39 @@
-require('geckodriver');
-require('chromedriver');
-
 const seleniumAssistant = require('selenium-assistant');
 
-Promise.all([
-  seleniumAssistant.downloadBrowser('firefox', 'stable', 50),
-  seleniumAssistant.downloadBrowser('chrome', 'stable', 48)
-])
-.then(x => {
-  console.log(`Downloaded browsers ${x}`);
-  process.exit(0);
-})
-.catch(e => {
-  console.error(`Error occured while downloading browsers ${e}`);
-  process.exit(1);
-});
+/**
+ * Download browsers.
+ * Parameters:
+ * @param {Array} browsers - a list of [browsers name, channel, expirationHours]. E.g.: ['chrome', 'stable', 48]
+ *
+ * @return {Promise} - a promise succesfully resolved when all browsers are downloaded.
+ */
+function downloadBrowsers(browsers) {
+  return Promise.all(browsers.map(item => {
+    const [browserName, channel, expirationHours] = item;
+    return seleniumAssistant
+      .downloadBrowser(browserName, channel, expirationHours);
+  }));
+}
+
+module.exports = {
+  downloadBrowsers
+};
+
+/**
+ * Download browsers using CLI:
+ *
+ * node browsers-helper.js chrome:stable:48 firefox:stable:50
+ */
+if (require.main === module) {
+  const browsers = process.argv.slice(2).map(item => item.split(':'));
+  console.log(`Downloading browsers: ${browsers.join(' ')}`);
+  downloadBrowsers(browsers)
+  .then(x => {
+    console.log(`Downloaded ${x.length} browsers.`);
+    process.exit(0);
+  })
+  .catch(e => {
+    console.error(`Error occured while downloading browsers ${e}`);
+    process.exit(1);
+  });
+}

--- a/src/helper/browsers-helper.js
+++ b/src/helper/browsers-helper.js
@@ -5,7 +5,11 @@ const seleniumAssistant = require('selenium-assistant');
 
 Promise.all([
   seleniumAssistant.downloadBrowser('firefox', 'stable', 48),
-  seleniumAssistant.downloadBrowser('chrome', 'stable', 48)
+  seleniumAssistant.downloadBrowser('firefox', 'beta', 48),
+  seleniumAssistant.downloadBrowser('firefox', 'unstable', 48),
+  seleniumAssistant.downloadBrowser('chrome', 'stable', 48),
+  seleniumAssistant.downloadBrowser('chrome', 'beta', 48),
+  seleniumAssistant.downloadBrowser('chrome', 'unstable', 48)
 ])
 .then(x => {
   console.log(`Downloaded browsers ${x}`);

--- a/src/helper/browsers-helper.js
+++ b/src/helper/browsers-helper.js
@@ -1,0 +1,19 @@
+require('geckodriver');
+require('chromedriver');
+
+const seleniumAssistant = require('selenium-assistant');
+
+Promise.all([
+  seleniumAssistant.downloadBrowser('firefox', 'stable', 48),
+  seleniumAssistant.downloadBrowser('firefox', 'beta', 48),
+  seleniumAssistant.downloadBrowser('firefox', 'unstable', 48),
+  seleniumAssistant.downloadBrowser('chrome', 'stable', 48),
+  seleniumAssistant.downloadBrowser('chrome', 'beta', 48),
+  seleniumAssistant.downloadBrowser('chrome', 'unstable', 48)
+])
+.then(x => {
+  console.log(`Downloaded browsers ${x}`);
+})
+.catch(e => {
+  console.error(`Error occured while downloading browsers ${e}`);
+});

--- a/src/index.js
+++ b/src/index.js
@@ -286,6 +286,7 @@ class WPTS {
 
         const options = seleniumAssistantBrowser.getSeleniumOptions();
         options.addArguments(`user-data-dir=${tempPreferenceFile}/`);
+        options.addArguments(`no-sandbox`);
       } else if (seleniumAssistantBrowser.getSeleniumBrowserId() ===
         'firefox') {
         const ffProfile = new seleniumFirefox.Profile();

--- a/src/index.js
+++ b/src/index.js
@@ -63,7 +63,11 @@ class WPTS {
   downloadBrowsers() {
     return Promise.all([
       seleniumAssistant.downloadBrowser('firefox', 'stable', 48),
-      seleniumAssistant.downloadBrowser('chrome', 'stable', 48)
+      seleniumAssistant.downloadBrowser('firefox', 'beta', 48),
+      seleniumAssistant.downloadBrowser('firefox', 'unstable', 48),
+      seleniumAssistant.downloadBrowser('chrome', 'stable', 48),
+      seleniumAssistant.downloadBrowser('chrome', 'beta', 48),
+      seleniumAssistant.downloadBrowser('chrome', 'unstable', 48)
     ]);
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -63,11 +63,7 @@ class WPTS {
   downloadBrowsers() {
     return Promise.all([
       seleniumAssistant.downloadBrowser('firefox', 'stable', 48),
-      seleniumAssistant.downloadBrowser('firefox', 'beta', 48),
-      seleniumAssistant.downloadBrowser('firefox', 'unstable', 48),
-      seleniumAssistant.downloadBrowser('chrome', 'stable', 48),
-      seleniumAssistant.downloadBrowser('chrome', 'beta', 48),
-      seleniumAssistant.downloadBrowser('chrome', 'unstable', 48)
+      seleniumAssistant.downloadBrowser('chrome', 'stable', 48)
     ]);
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -25,22 +25,23 @@ const mkdirp = require('mkdirp');
 const seleniumFirefox = require('selenium-webdriver/firefox');
 
 const logHelper = require('./helper/log-helper.js');
+const browsersHelper = require('./helper/browsers-helper');
 const APIServer = require('./server/api-server.js');
 const TestSuite = require('./model/test-suite.js');
 
 // This may be needed: https://github.com/angular/protractor/issues/2419#issuecomment-213112857
 
 class WPTS {
-  constructor(port) {
+  constructor(port, supportedBrowsers, supportedVersions) {
     port = port ? port : 8090;
 
     this._availableTestSuiteId = 0;
     this._testSuites = {};
-    this._supportedBrowsers = [
+    this._supportedBrowsers = supportedBrowsers || [
       'chrome',
       'firefox'
     ];
-    this._supportedBrowserVersions = [
+    this._supportedBrowserVersions = supportedVersions || [
       'stable',
       'beta',
       'unstable'
@@ -60,16 +61,18 @@ class WPTS {
     logHelper.setLogFile(logFile);
   }
 
-  downloadBrowsers() {
-    return Promise.all([
-      seleniumAssistant.downloadBrowser('firefox', 'stable', 50),
-      seleniumAssistant.downloadBrowser('chrome', 'stable', 48)
-    ]);
+  downloadBrowsers(browsers) {
+    return browsersHelper.downloadBrowsers(browsers);
   }
 
   startService() {
-    return this.downloadBrowsers()
+    const browsers = this._supportedBrowsers.reduce((acc, name) => {
+      return acc.concat(this._supportedBrowserVersions.map(v => [name, v]));
+    }, []);
+    logHelper.info(`Downloading browsers: ${browsers.join(' ')}`);
+    return this.downloadBrowsers(browsers)
     .then(() => {
+      logHelper.info('Browsers downloaded');
       return this._apiServer.startListening();
     });
   }

--- a/src/index.js
+++ b/src/index.js
@@ -62,7 +62,7 @@ class WPTS {
 
   downloadBrowsers() {
     return Promise.all([
-      seleniumAssistant.downloadBrowser('firefox', 'stable', 48),
+      seleniumAssistant.downloadBrowser('firefox', 'stable', 50),
       seleniumAssistant.downloadBrowser('chrome', 'stable', 48)
     ]);
   }

--- a/src/server/api-server.js
+++ b/src/server/api-server.js
@@ -32,7 +32,8 @@ class APIServer extends EventEmitter {
     }
 
     this._port = port;
-    this._host = '0.0.0.0';
+    this._host = 'localhost';
+    this._serveHost = '0.0.0.0';
 
     this._expressApp = express();
     this._expressApp.use(bodyParser.json());
@@ -77,7 +78,7 @@ class APIServer extends EventEmitter {
   startListening() {
     return new Promise((resolve, reject) => {
       this._expressServer = this._expressApp.listen(
-        this._port, this._host, () => {
+        this._port, this._serveHost, () => {
           resolve(this.getUrl());
         }
       );

--- a/src/server/api-server.js
+++ b/src/server/api-server.js
@@ -32,7 +32,7 @@ class APIServer extends EventEmitter {
     }
 
     this._port = port;
-    this._host = 'localhost';
+    this._host = '0.0.0.0';
 
     this._expressApp = express();
     this._expressApp.use(bodyParser.json());


### PR DESCRIPTION
Just made a few changes to make it easier to gear up the service to run in a Docker container:

 * Override default browser to be downloaded (and download them before starting the app)
 * Serve the API on `0.0.0.0` exposed to Docker network.
 * Added `no sandbox` parameter to make Chrome happy when running in xvfb. (Shall this be optional?) 