### PR TITLE
Bump version selenium-assistant

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-push-testing-service",
   "description": "A service that can be run locally or on a CLI to manage testing of web push in a language agnostic way",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "bin": {
     "web-push-testing-service": "./src/bin/cli.js"
   },
@@ -15,7 +15,7 @@
     "minimist": "^1.2.0",
     "mkdirp": "^0.5.1",
     "node-persist": "^2.0.2",
-    "selenium-assistant": "5.2.0",
+    "selenium-assistant": "^5.3.0",
     "web-push": "^3.1.0",
     "winston": "^2.2.0"
   },


### PR DESCRIPTION
I tried to run web-push-testing-service 0.4.0, but it fails because it cannot find `FirefoxNightly.app` after mounting the .dmg. I noticed that there was a `Firefox Nightly.app` on the file system. It looks like selenium-assistant 5.3.0 [fixed](https://github.com/GoogleChromeLabs/selenium-assistant/pull/109/files#diff-396f2ed14148078d19a30f7c08b4eedeR298) this a while back, but web-push-testing-service still uses selenium-assistant 5.2.0.

This PR:

* Updates the dependency on selenium-assistant from 5.2.0 to ^5.3.0
* Updates the package-lock.json accordingly (I just ran `npm i selenium-assistant`)
* Bumps the version of selenium-assistant.

Let me know if this is okay or if it needs any improvements.